### PR TITLE
Add simulation data recordings management support

### DIFF
--- a/conf/bootstraps/functions.sh
+++ b/conf/bootstraps/functions.sh
@@ -45,3 +45,18 @@ function update_resource() {
       return 1
   fi
 }
+
+# Upload recording
+function upload_recording() {
+  endpoint=$1
+  filename=$2
+
+  curl -s -d "$filename" \
+      -H "Content-Type: text/plain" \
+      -X POST \
+      $endpoint
+
+  if [ $? -ne 0 ]; then
+      return 1
+  fi
+}

--- a/conf/bootstraps/minimal.sh
+++ b/conf/bootstraps/minimal.sh
@@ -46,8 +46,10 @@ user_id=$(create_resource "$req" $ENDPOINT/users)
 # Bind SNMP USM user to SNMP engine
 update_resource $ENDPOINT/engines/$engine_id/user/$user_id
 
+
 # Bind SNMP engine to SNMP agent
 update_resource $ENDPOINT/agents/$agent_id/engine/$engine_id
+
 
 # Create SNMP transport endpoint
 req='{
@@ -58,12 +60,28 @@ req='{
 
 endpoint_id=$(create_resource "$req" $ENDPOINT/endpoints)
 
-
 # Bind SNMP transport endpoint to SNMP engine
 update_resource $ENDPOINT/engines/$engine_id/endpoint/$endpoint_id
 
+
 # Bind SNMP agent to virtual lab
 update_resource $ENDPOINT/labs/$lab_id/agent/$agent_id
+
+# Upload a sample .snmprec file
+snmprec_file=/tmp/public.snmprec
+
+cat > $snmprec_file <<EOF
+1.3.6.1.2.1.1.1.0|4|Linux zeus 4.8.6.5-smp #2 SMP Sun Nov 13 14:58:11 CDT 2016 i686
+1.3.6.1.2.1.1.2.0|6|1.3.6.1.4.1.8072.3.2.10
+1.3.6.1.2.1.1.3.0|67:numeric|rate=100,initial=123999999
+1.3.6.1.2.1.1.4.0|4|SNMP Laboratories, info@snmplabs.com
+1.3.6.1.2.1.1.5.0|4:writecache|value=zeus.snmplabs.com (you can change this!)
+1.3.6.1.2.1.1.6.0|4|San Francisco, California, United States
+1.3.6.1.2.1.1.7.0|2|72
+1.3.6.1.2.1.1.8.0|67:numeric|rate=100,initial=123999999
+EOF
+
+upload_recording $ENDPOINT/recordings/public.snmprec $snmprec_file
 
 # Power ON the lab
 update_resource $ENDPOINT/labs/$lab_id/power/on

--- a/docs/snmpsim-mgmt-api.yaml
+++ b/docs/snmpsim-mgmt-api.yaml
@@ -161,23 +161,60 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
+  /recordings/{path}:
+    description: >
+      This resource represents a single simulation data recording identified
+      by `path`.
+    get:
+      summary: Info for a specific simulation data object
+      parameters:
+        - name: path
+          in: path
+          required: true
+          description: Simulation file path relative to data root
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Simulation file contents
+          content:
+            text/plain:
+              schema:
+                type: string
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
     post:
       summary: Create a new simulation data recording
-      tags:
-        - recordings
+      parameters:
+        - name: path
+          in: path
+          required: true
+          description: Simulation file path relative to data root
+          schema:
+            type: string
       requestBody:
         description: >
-          Receive the entire .snmprec file in a JSON object or ASCII text form.
+          Receive the entire .snmprec file in a text or compressed form.
         required: true
         content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RecordingRequired"
           text/plain:
             schema:
               type: string
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
       responses:
-        "201":
+        "204":
           description: Null response
         default:
           description: Unspecified error
@@ -185,48 +222,17 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-
-  /recordings/{id}:
-    description: >
-      This resource represents a single simulation data recording identified
-      by `id`.
-    get:
-      summary: Info for a specific simulation data object
-      tags:
-        - recordings
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: The ID of the object to retrieve
-          schema:
-            type: integer
-      responses:
-        "200":
-          description: Expected response to a valid request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Recording"
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
     delete:
       summary: Delete simulation data object
-      tags:
-        - recordings
       parameters:
-        - name: id
+        - name: path
           in: path
           required: true
-          description: The ID of the object to retrieve
+          description: Simulation file path relative to data root
           schema:
-            type: integer
+            type: string
       responses:
-        "201":
+        "204":
           description: Null response
         default:
           description: Unspecified error

--- a/snmpsim_control_plane/commands/management.py
+++ b/snmpsim_control_plane/commands/management.py
@@ -13,6 +13,7 @@ import sys
 
 from snmpsim_control_plane.management import app
 from snmpsim_control_plane.management import db
+from snmpsim_control_plane.management import views  # noqa
 
 DESCRIPTION = """\
 SNMP Simulation Control Plane REST API server.

--- a/snmpsim_control_plane/management/exporters/builder.py
+++ b/snmpsim_control_plane/management/exporters/builder.py
@@ -9,7 +9,7 @@
 from sqlalchemy import and_
 from sqlalchemy import inspect
 
-from snmpsim_control_plane.management import mgmt as models
+from snmpsim_control_plane.management import models
 
 
 def object_as_dict(obj):

--- a/snmpsim_control_plane/management/models.py
+++ b/snmpsim_control_plane/management/models.py
@@ -138,12 +138,6 @@ class AgentSelector(db.Model):
     )
 
 
-class Recording(db.Model):
-    id = db.Column(db.Integer(), primary_key=True)
-    name = db.Column(db.String(60))
-    path = db.Column(db.String(), unique=True, nullable=False)
-
-
 class Lab(db.Model):
     id = db.Column(db.Integer(), primary_key=True)
     name = db.Column(db.String(), nullable=True)

--- a/snmpsim_control_plane/management/recording.py
+++ b/snmpsim_control_plane/management/recording.py
@@ -1,0 +1,87 @@
+#
+# This file is part of SNMP simulator Control Plane software.
+#
+# Copyright (c) 2019, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/snmpsim/license.html
+#
+# SNMP simulator management: data simulation recording management
+#
+import os
+
+from snmpsim_control_plane import log
+from snmpsim_control_plane import error
+
+
+KNOWN_EXTENSIONS = {
+    '.snmprec': 'snmprec',
+    '.sapwalk': 'sapwalk',
+    '.snmpwalk': 'snmpwalk'
+}
+
+
+def _traverse_dir(directory):
+    files = []
+    entries = os.listdir(directory)
+
+    for entry in entries:
+        dir_or_file = os.path.join(directory, entry)
+        if os.path.isdir(dir_or_file):
+            files.extend(_traverse_dir(dir_or_file))
+
+        else:
+            files.append(dir_or_file)
+
+    return files
+
+
+def get_recording_type(filename):
+    for ext in KNOWN_EXTENSIONS:
+        if filename.endswith(ext):
+            return KNOWN_EXTENSIONS[ext]
+
+
+def list_recordings(data_dir):
+
+    try:
+        files = _traverse_dir(data_dir)
+
+    except Exception as exc:
+        raise error.ControlPlaneError(
+            'Directory %s traversal failure: %s' % (data_dir, exc))
+
+    recordings = []
+
+    for filename in files:
+        stat = os.stat(filename, follow_symlinks=True)
+
+        recording_type = get_recording_type(filename)
+        if not recording_type:
+            continue
+
+        recording = {
+            'path': filename[len(data_dir) + 1:],
+            'size': stat.st_size,
+            'type': recording_type
+        }
+
+        recordings.append(recording)
+
+    return recordings
+
+
+def get_recording(data_dir, filename, exists=False, not_exists=False):
+    filename = os.path.abspath(os.path.join(data_dir, filename))
+
+    if not filename.startswith(data_dir):
+        log.error('Requested recording %s is outside of data root' % filename)
+        raise error.ControlPlaneError('No such recording')
+
+    if exists and not os.path.exists(filename):
+        log.error('Requested recording %s does not exist' % filename)
+        raise error.ControlPlaneError('No such recording')
+
+    if not_exists and os.path.exists(filename):
+        log.error('Requested recording %s unexpectedly exists' % filename)
+        raise error.ControlPlaneError('No such recording')
+
+    return os.path.dirname(filename), os.path.basename(filename)

--- a/snmpsim_control_plane/management/schemas.py
+++ b/snmpsim_control_plane/management/schemas.py
@@ -87,7 +87,7 @@ class AgentSchema(ma.ModelSchema):
 
 class RecordingSchema(ma.ModelSchema):
     class Meta:
-        model = models.Recording
+        fields = ('path', 'size', 'type')
 
 
 class LabSchema(ma.ModelSchema):


### PR DESCRIPTION
Prior to this commit, simulation data recordings were modelled entirely in the database. This commit removes any DB backing for simulation files, instead Management REST API server operates on the data directory directly.
    
REST API client can list, download, upload and remove of SNMP simulation data records of their choice.
