### PR TITLE
Add process metrics models and importer

### DIFF
--- a/snmpsim_control_plane/metrics/importers/process.py
+++ b/snmpsim_control_plane/metrics/importers/process.py
@@ -1,0 +1,150 @@
+#
+# This file is part of SNMP simulator Control Plane software.
+#
+# Copyright (c) 2019-2020, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/snmpsim/license.html
+#
+# SNMP simulator metrics: supervisor metrics importer
+#
+from snmpsim_control_plane.metrics import db
+from snmpsim_control_plane.metrics import models
+from snmpsim_control_plane.metrics.utils import autoincrement
+
+
+MAX_CONSOLE_PAGES = 50
+
+
+def import_metrics(jsondoc):
+    """Update metrics DB from `dict` data structure
+
+    The input data structure is expected to be the one produced by SNMP
+    simulator's command responder `fulljson` reporting module.
+
+
+
+    .. code-block:: python
+
+    {
+        'format': 'jsondoc',
+        'version': 1,
+        'host': '{hostname}',
+        'producer': <UUID>,
+        'first_update': '{timestamp}',
+        'last_update': '{timestamp}',
+        'executables': [
+            {
+                'executable': '{path}',
+                'runtime': '{seconds}',
+                'memory': {MB},
+                'cpu': {ms},
+                'files': 0,
+                'exits': 0,
+                'changes': 0,
+                'endpoints': {
+                    'udpv4': [
+                        '127.0.0.1:161'
+                    ],
+                    'udpv6': [
+                        '::1:161'
+                    ]
+                ],
+                'console': [
+                    {
+                        'page': 0,
+                        'timestamp': 0,
+                        'text': '{text}'
+                    }
+                ]
+            }
+        ]
+    }
+    """
+    supervisor_model = models.Supervisor(
+        hostname=jsondoc['host'],
+        producer=jsondoc['producer']
+    )
+
+    supervisor_model = db.session.merge(supervisor_model)
+
+    autoincrement(supervisor_model, models.Supervisor)
+
+    for executable in jsondoc['executables']:
+
+        executable_model = models.Executable(
+            path=executable['executable'],
+            supervisor_id=supervisor_model.id
+        )
+
+        executable_model = db.session.merge(executable_model)
+
+        autoincrement(executable_model, models.Executable)
+
+        process_model = models.Process(
+            executable_id=executable_model.id
+        )
+
+        process_model = db.session.merge(process_model)
+
+        autoincrement(process_model, models.Process)
+
+        process_model.runtime = process_model.runtime or 0
+        process_model.runtime += executable['runtime']
+
+        process_model.memory = executable['memory']
+
+        process_model.cpu = process_model.cpu or 0
+        process_model.cpu += executable['cpu']
+
+        process_model.files = executable['files']
+
+        process_model.exits = process_model.exits or 0
+        process_model.exits += executable['exits']
+
+        process_model.changes = process_model.changes or 0
+        process_model.changes += executable['changes']
+
+        process_model.last_update = jsondoc['last_update']
+
+        query = (
+            models.Endpoint
+            .query
+            .filter_by(process_id=process_model.id)
+        )
+        query.delete()
+
+        for protocol, addresses in executable['endpoints']:
+
+            for address in addresses:
+                endpoint_model = models.Endpoint(
+                    protocol=protocol,
+                    address=address,
+                    process_id=process_model.id
+                )
+
+                db.session.add(endpoint_model)
+
+        query = (
+            models.ConsolePage
+            .query
+            .filter_by(process_id=process_model.id)
+            .order_by(models.ConsolePage.timestamp.asc())
+        )
+        console_pages_count = query.count()
+
+        while console_pages_count > MAX_CONSOLE_PAGES:
+            console_page = query.first()
+            db.session.delete(console_page)
+            console_pages_count -= 1
+
+        for console_page in executable['console']:
+
+            console_page_model = models.ConsolePage(
+                page=console_page['page'],
+                timestamp=console_page['timestamp'],
+                text=console_page['text'],
+                process_id=process_model.id
+            )
+
+            db.session.add(console_page_model)
+
+        db.session.commit()

--- a/snmpsim_control_plane/metrics/importers/snmpagent.py
+++ b/snmpsim_control_plane/metrics/importers/snmpagent.py
@@ -4,28 +4,11 @@
 # Copyright (c) 2019-2020, Ilya Etingof <etingof@gmail.com>
 # License: http://snmplabs.com/snmpsim/license.html
 #
-# SNMP simulator metrics: ORM models importer
+# SNMP simulator metrics: snmpsim metrics importer
 #
-from sqlalchemy import func
-
 from snmpsim_control_plane.metrics import db
 from snmpsim_control_plane.metrics import models
-
-
-def autoincrement(obj, model):
-    """Add unique ID to model.
-
-    Sqlalchemy's merge requires unique fields being primary keys. On top of
-    that, autoincrement does not always work with Sqlalchemy. Thus this
-    hack to generate unique row ID. %-(
-    """
-    if obj.id is None:
-        max_id = db.session.query(func.max(model.id)).first()
-        max_id = max_id[0]
-        max_id = max_id + 1 if max_id else 1
-        obj.id = max_id
-
-        db.session.commit()
+from snmpsim_control_plane.metrics.utils import autoincrement
 
 
 def import_metrics(fulljson):

--- a/snmpsim_control_plane/metrics/manager.py
+++ b/snmpsim_control_plane/metrics/manager.py
@@ -6,12 +6,15 @@
 #
 # SNMP Agent Simulator Control Plane: metrics importer manager
 #
-from snmpsim_control_plane.metrics.importers import fulljson
-from snmpsim_control_plane import log
+from snmpsim_control_plane.metrics import db
 
+from snmpsim_control_plane import log
+from snmpsim_control_plane.metrics.importers import snmpagent
+from snmpsim_control_plane.metrics.importers import process
 
 KNOWN_IMPORTERS = {
-    'fulljson': fulljson.import_metrics,
+    'fulljson': snmpagent.import_metrics,
+    'jsondoc': process.import_metrics,
 }
 
 
@@ -28,4 +31,10 @@ def import_metrics(jsondoc):
                   'ignoring' % flavor or '<unspecified>')
         return
 
-    importer(jsondoc)
+    try:
+        importer(jsondoc)
+
+    except Exception as exc:
+        log.error('Metric importer %s failed: %s' % (flavor, exc))
+        log.debug('JSON document causing failure is: %s' % jsondoc)
+        db.session.rollback()

--- a/snmpsim_control_plane/metrics/models.py
+++ b/snmpsim_control_plane/metrics/models.py
@@ -126,3 +126,71 @@ class Variation(db.Model):
             'pdu_id', 'name'
         ),
     )
+
+
+class Endpoint(db.Model):
+    protocol = db.Column(db.String(), nullable=False)
+    address = db.Column(db.String(), nullable=False)
+    process_id = db.Column(db.Integer(), db.ForeignKey('process.id'))
+
+    __table_args__ = (
+        db.PrimaryKeyConstraint('protocol', 'address', 'process_id'),
+    )
+
+
+class ConsolePage(db.Model):
+    page = db.Column(db.Integer(), nullable=False)
+    text = db.Column(db.String(), nullable=False)
+    timestamp = db.Column(db.Integer(), nullable=False)
+    process_id = db.Column(db.Integer(), db.ForeignKey('process.id'))
+
+    __table_args__ = (
+        db.PrimaryKeyConstraint('process_id', 'page'),
+    )
+
+
+class Process(db.Model):
+    id = db.Column(db.Integer(), unique=True)
+    runtime = db.Column(db.Integer())
+    memory = db.Column(db.Integer())
+    cpu = db.Column(db.Integer())
+    files = db.Column(db.Integer())
+    exits = db.Column(db.Integer())
+    changes = db.Column(db.Integer())
+    last_update = db.Column(db.Integer())
+    executable_id = db.Column(db.Integer(), db.ForeignKey('executable.id'))
+
+    endpoints = db.relationship(
+        'Endpoint', backref='process', lazy=True)
+    console_pages = db.relationship(
+        'ConsolePage', backref='process', lazy=True)
+
+    __table_args__ = (
+        db.PrimaryKeyConstraint('executable_id'),
+    )
+
+
+class Executable(db.Model):
+    id = db.Column(db.Integer(), unique=True)
+    path = db.Column(db.String(), nullable=False)
+    supervisor_id = db.Column(db.Integer(), db.ForeignKey('supervisor.id'))
+
+    process = db.relationship(
+        'Process', uselist=False, backref='executable', lazy=True)
+
+    __table_args__ = (
+        db.PrimaryKeyConstraint('path', 'supervisor_id'),
+    )
+
+
+class Supervisor(db.Model):
+    id = db.Column(db.Integer(), unique=True)
+    hostname = db.Column(db.String(), nullable=False)
+    producer = db.Column(db.String(), nullable=False)
+
+    executables = db.relationship(
+        'Executable', backref='supervisor', lazy=True)
+
+    __table_args__ = (
+        db.PrimaryKeyConstraint('hostname', 'producer'),
+    )

--- a/snmpsim_control_plane/metrics/reader.py
+++ b/snmpsim_control_plane/metrics/reader.py
@@ -11,7 +11,7 @@ import json
 import time
 
 from snmpsim_control_plane import log
-from snmpsim_control_plane.metrics.importers import manager
+from snmpsim_control_plane.metrics import manager
 
 POLL_PERIOD = 10
 

--- a/snmpsim_control_plane/metrics/utils.py
+++ b/snmpsim_control_plane/metrics/utils.py
@@ -1,0 +1,28 @@
+#
+# This file is part of SNMP simulator Control Plane software.
+#
+# Copyright (c) 2019-2020, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/snmpsim/license.html
+#
+# SNMP simulator metrics: snmpsim metrics helpers
+#
+from sqlalchemy import func
+
+from snmpsim_control_plane.metrics import db
+
+
+def autoincrement(obj, model):
+    """Add unique ID to model.
+
+    Sqlalchemy's merge requires unique fields being primary keys. On top of
+    that, autoincrement does not always work with Sqlalchemy. Thus this
+    hack to generate unique row ID. %-(
+    """
+    if obj.id is None:
+        max_id = db.session.query(func.max(model.id)).first()
+        max_id = max_id[0]
+        max_id = max_id + 1 if max_id else 1
+        obj.id = max_id
+
+        db.session.commit()
+

--- a/snmpsim_control_plane/supervisor/lifecycle.py
+++ b/snmpsim_control_plane/supervisor/lifecycle.py
@@ -73,6 +73,7 @@ class ConsoleLog(AbstractGrowingValue):
         self._first_page = first_page
         self._last_page = first_page
         self._text = {}
+        self._timestamps = {}
 
     @property
     def first_page(self):
@@ -82,20 +83,21 @@ class ConsoleLog(AbstractGrowingValue):
     def last_page(self):
         return self._last_page - 1
 
-    def add(self, text):
+    def add(self, text, timestamp):
         self._text[self._last_page] = text
+        self._timestamps[self._last_page] = timestamp
         self._last_page += 1
 
         if len(self._text) > self.MAX_CONSOLES:
             self._text.pop(self._first_page)
+            self._timestamps.pop(self._first_page)
             self._first_page += 1
 
-    def __getitem__(self, item):
-        try:
-            return self._text[item]
+    def text(self, page):
+        return self._text.get(page, '')
 
-        except KeyError as exc:
-            raise IndexError(exc)
+    def timestamp(self, page):
+        return self._timestamps.get(page, '')
 
     @property
     def latest(self):
@@ -105,8 +107,8 @@ class ConsoleLog(AbstractGrowingValue):
         first_page = relative_to or 0
         console = self.__class__(first_page=first_page)
 
-        for page in range(first_page, self.last_page + 1):
-            console.add(self[page])
+        for page in range(first_page, self.last_page):
+            console.add(self.text(page), self.timestamp(page))
 
         return console
 

--- a/snmpsim_control_plane/supervisor/manager.py
+++ b/snmpsim_control_plane/supervisor/manager.py
@@ -91,6 +91,8 @@ def manage_executables(watch_dir):
             if not r:
                 break
 
+            timestamp = int(time.time())
+
             for fd in r:
                 executable = rlist[fd]
                 instance = known_instances[executable]
@@ -101,7 +103,7 @@ def manage_executables(watch_dir):
                 page_text = os.read(fd, console.MAX_CONSOLE_SIZE)
                 page_text = page_text.decode(errors='ignore')
 
-                console.add(page_text)
+                console.add(page_text, timestamp)
 
                 log.msg(page_text)
                 log.msg('Output from process "%s" ends' % executable)

--- a/snmpsim_control_plane/supervisor/reporting/formats/jsondoc.py
+++ b/snmpsim_control_plane/supervisor/reporting/formats/jsondoc.py
@@ -52,6 +52,7 @@ class JsonDocReporter(base.BaseReporter):
                 'console': [
                     {
                         'page': 0,
+                        'timestamp': 0,
                         'text': '{text}'
                     }
                 ]
@@ -101,7 +102,9 @@ class JsonDocReporter(base.BaseReporter):
     def _json_serializer(obj):
         if isinstance(obj, lifecycle.ConsoleLog):
             return [
-                {'page': page, 'text': obj[page]}
+                {'page': page,
+                 'text': obj.text(page),
+                 'timestamp': obj.timestamp(page)}
                 for page in range(obj.first_page, obj.last_page + 1)
             ]
 


### PR DESCRIPTION
Up to this commit, `snmpsim-supervisor` process generates metrics, `snmpsim-metrics-importer` loads them into the DB. No REST API access yet though.