### PR TITLE
Add process metrics API endpoints

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,9 @@
 Revision 0.0.2, released XX-01-2020
 -----------------------------------
 
-No changes yet
+- Added SNMP simulator processes runtime metrics collection by the
+  `supervisor` process. Gathered information is stored in the DB
+  and served via newly introduced REST API endpoints.
 
 Revision 0.0.1, released 14-01-2020
 -----------------------------------

--- a/docs/specs/snmpsim-metrics-api.yaml
+++ b/docs/specs/snmpsim-metrics-api.yaml
@@ -243,38 +243,328 @@ paths:
   /processes:
     get:
       description: >
-        Collection of SNMP simulator system process information.
+        Collection of SNMP simulator process information.
       summary: >
-        Search for and list process information.
+        A list of SNMP simulator process information.
+      responses:
+        "200":
+          description: >
+            An array of process information objects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessesMetricsArray"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /processes/{id}:
+    get:
+      description: >
+        SNMP simulator process information identified by `id`.
+      summary: >
+        SNMP simulator process information.
       parameters:
-        - name: newer
-          in: query
-          description: >
-            Select processes with uptime lesser than specified.
-          required: false
+        - name: id
+          in: path
+          required: true
+          description: The ID of the SNMP simulator process
           schema:
             type: integer
-        - name: larger
-          in: query
+      responses:
+        "200":
           description: >
-            Select processes with the amount of consumed memory larger
-            than specified.
-          required: false
+            Process information object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessMetrics"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /processes/{id}/endpoints:
+    get:
+      description: >
+        List of transport endpoints bound by SNMP simulator process identified
+        by `id`.
+      summary: >
+        SNMP simulator transport endpoint information.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the SNMP simulator process
           schema:
             type: integer
-        - name: hotter
-          in: query
+      responses:
+        "200":
           description: >
-            Select processes with CPU utilization higher than specified.
-          required: false
+            An array of transport endpoints information objects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EndpointMetricsArray"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /processes/{id}/endpoints/{endpoint_id}:
+    get:
+      description: >
+        Returns specific transport endpoint information identified by
+        `endpoint_id` bound by SNMP simulator process identified
+        by `id`.
+      summary: >
+        SNMP simulator transport endpoint information.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the SNMP simulator process
           schema:
             type: integer
-        - name: sicker
-          in: query
+        - name: endpoint_id
+          in: path
+          required: true
+          description: The ID of the SNMP simulator transport endpoint
+          schema:
+            type: integer
+      responses:
+        "200":
           description: >
-            Select processes with fatal, critical and warning counters
-            greater than specified.
-          required: false
+            Transport endpoint information object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EndpointMetrics"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /processes/{id}/console:
+    get:
+      description: >
+        Returns the contents of all SNMP simulator process console pages for
+        SNMP simulator process identified by `id`.
+      summary: >
+        SNMP simulator console pages.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the SNMP simulator process
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: >
+            List of console page objects.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConsolePageArray"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /processes/{id}/console/{page_id}:
+    get:
+      description: >
+        Returns the contents of one SNMP simulator process console page
+        identified by `page_id` for SNMP simulator process identified
+        by `id`.
+      summary: >
+        SNMP simulator console page.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the SNMP simulator process
+          schema:
+            type: integer
+        - name: page_id
+          in: path
+          required: true
+          description: The ID of the SNMP simulator console page
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: >
+            Console page object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConsolePage"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /consoles/{id}:
+    get:
+      description: >
+        Returns the contents of all SNMP simulator process console pages for
+        SNMP simulator process identified by `id`.
+      summary: >
+        SNMP simulator console pages.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the SNMP simulator process
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: >
+            List of console page objects.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConsolePageArray"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /consoles/{id}/page/{page_id}:
+    get:
+      description: >
+        Returns the contents of one SNMP simulator process console page
+        identified by `page_id` for SNMP simulator process identified
+        by `id`.
+      summary: >
+        SNMP simulator console page.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the SNMP simulator process
+          schema:
+            type: integer
+        - name: page_id
+          in: path
+          required: true
+          description: The ID of the SNMP simulator console page
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: >
+            Console page object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConsolePage"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /endpoints:
+    get:
+      description: >
+        List of transport endpoints bound by all SNMP simulator processes.
+      summary: >
+        SNMP simulator transport endpoint information.
+      responses:
+        "200":
+          description: >
+            An array of SNMP simulator transport endpoint information objects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EndpointMetricsArray"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /endpoints/{id}:
+    get:
+      description: >
+        Return SNMP simulator transport endpoint information identified
+        by `id`.
+      summary: >
+        SNMP simulator transport endpoint information
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the transport endpoint
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: >
+            SNMP simulator transport information object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EndpointMetrics"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /supervisors:
+    get:
+      description: >
+        Collection of SNMP simulator supervisor process information.
+      summary: >
+        A list of supervisor process information.
+      responses:
+        "200":
+          description: >
+            An array of supervisor information objects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SupervisorMetricsArray"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /supervisors/{id}:
+    get:
+      description: >
+        SNMP simulator supervisor process information.
+      summary: >
+        Individual supervisor process information.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the supervisor process
           schema:
             type: integer
       responses:
@@ -284,7 +574,36 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProcessesMetrics"
+                $ref: "#/components/schemas/SupervisorMetrics"
+        default:
+          description: Unspecified error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /supervisors/{id}/processes:
+    get:
+      description: >
+        SNMP simulator process information for processes belonging to the
+        supervisor identified by `id`.
+      summary: >
+        SNMP simulator process information.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The ID of the supervisor process
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: >
+            An array of process information objects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessesMetricsArray"
         default:
           description: Unspecified error
           content:
@@ -389,10 +708,44 @@ components:
       additionalProperties:
         type: string
 
+    SupervisorMetrics:
+      description: >
+        SNMP simulator system is composed of potentially many running
+        processes. These processes are collectively managed by a single
+        `supervisor` process.
+
+        This object describes `supervisor` process setup and activity.
+      type: object
+      properties:
+        hostname:
+          description: >
+            Hostname of the host where this `supervisor` process is running.
+          type: string
+        watch_dir:
+          description: >
+            The directory being watched by this `supervisor` process for
+            executables to invoke and keep running. The pair of `hostname` and
+            `watch_dir` should uniquely identify each `supervisor` instance (if
+            more than one is running).
+          type: string
+        started:
+          description: >
+            Time stamp indicating when this `supervisor` instance has been
+            started.
+          type: string
+
+    SupervisorMetricsArray:
+      description: >
+        An array of process information objects.
+      type: array
+      items:
+        $ref: "#/components/schemas/SupervisorMetrics"
+
     ProcessMetrics:
       description: >
         SNMP simulator system is composed of potentially many running
-        processes. Each process is created by running the executable.
+        processes. Each process is created by `supervisor` by running the
+        executable.
 
         This object describes resources consumption for the currently
         running process and accumulated for all processes created from
@@ -400,14 +753,14 @@ components:
         system.
       type: object
       properties:
-        executable:
+        path:
           description: >
-            Path to process executable and its command-line parameters.
+            Path to process executable.
           type: string
         runtime:
           description: >
             For how long all processes created from this executable has been
-            running so far (in seconds).
+            running (in seconds).
           type: integer
         memory:
           description: >
@@ -431,53 +784,79 @@ components:
           description: >
             How many times this executable has been changed and restarted.
           type: integer
-        endpoints:
+        last_update:
           description: >
-            Network endpoints the currently running process has opened.
-          type: object
-          properties:
-            udpv4:
-              description: >
-                UDP/IPv4 endpoints
-              type: array
-              items:
-                description:
-                  IP:port
-                type: string
-            udpv6:
-              description: >
-                UDP/IPv6 endpoints
-              type: array
-              items:
-                description:
-                  IP:port
-                type: string
-        console:
-          description: >
-            Pages of text that appeared so far on process stdout&stderr organized
-            in sequentially numbered pages. Older pages might be dropped from the
-            underlying database.
-          type: array
-          items:
-            type: object
-            description: >
-              A single console page
-            properties:
-              page:
-                description: >
-                  Page number, ever increasing
-                type: integer
-              text:
-                description: >
-                  Page text
-                type: string
+            Time stamp indicating when process information is last updated.
+          type: string
 
-    ProcessesMetrics:
+        endpoints:
+          $ref: "#/components/schemas/EndpointMetricsArray"
+
+        console:
+          $ref: "#/components/schemas/ConsolePageArray"
+
+    ProcessesMetricsArray:
       description: >
-        An array of process information.
+        An array of process information objects.
       type: array
       items:
         $ref: "#/components/schemas/ProcessMetrics"
+
+    EndpointMetrics:
+      description: >
+        SNMP simulator process binds and listens on one or many transport
+        endpoints (local network interfaces and UDP ports).
+
+        This object describes transport endpoints being used by any given
+        SNMP simulator process.
+      type: object
+      properties:
+        protocol:
+          description: >
+            Network protocol used by this endpoint
+          type: string
+          enum: ['udpv4', 'udpv6']
+
+        address:
+          description: >
+            Network address used by this endpoint (IP:port)
+          type: string
+
+    EndpointMetricsArray:
+      description: >
+        An array of transport endpoint information objects.
+      type: array
+      items:
+        $ref: "#/components/schemas/EndpointMetrics"
+
+    ConsolePage:
+      description: >
+        SNMP simulator process can output some diagnostics on its stdout/stderr
+        streams. The `supervisor` process will capture that and place into the
+        database. Process output is chunked onto imaginary console "pages",
+        each addressable individually.
+
+        Console information is automatically expired over time.
+
+        This object describes a single console output page of a SNMP simulator
+        process.
+      type: object
+      properties:
+        timestamp:
+          description: >
+            Time indicating when this page has been captured
+          type: integer
+        text:
+          description: >
+            Page text
+          type: string
+
+    ConsolePageArray:
+      description: >
+        An array of console page objects.
+      type: array
+      items:
+        $ref: "#/components/schemas/ConsolePage"
 
     Error:
       type: object

--- a/snmpsim_control_plane/metrics/manager.py
+++ b/snmpsim_control_plane/metrics/manager.py
@@ -36,5 +36,5 @@ def import_metrics(jsondoc):
 
     except Exception as exc:
         log.error('Metric importer %s failed: %s' % (flavor, exc))
-        log.debug('JSON document causing failure is: %s' % jsondoc)
+        log.error('JSON document causing failure is: %s' % jsondoc)
         db.session.rollback()

--- a/snmpsim_control_plane/metrics/models.py
+++ b/snmpsim_control_plane/metrics/models.py
@@ -129,6 +129,7 @@ class Variation(db.Model):
 
 
 class Endpoint(db.Model):
+    id = db.Column(db.Integer(), unique=True)
     protocol = db.Column(db.String(), nullable=False)
     address = db.Column(db.String(), nullable=False)
     process_id = db.Column(db.Integer(), db.ForeignKey('process.id'))
@@ -139,26 +140,28 @@ class Endpoint(db.Model):
 
 
 class ConsolePage(db.Model):
-    page = db.Column(db.Integer(), nullable=False)
+    id = db.Column(db.Integer(), unique=True)
     text = db.Column(db.String(), nullable=False)
-    timestamp = db.Column(db.Integer(), nullable=False)
+    timestamp = db.Column(db.DateTime(), nullable=False)
     process_id = db.Column(db.Integer(), db.ForeignKey('process.id'))
 
     __table_args__ = (
-        db.PrimaryKeyConstraint('process_id', 'page'),
+        db.PrimaryKeyConstraint('id', 'process_id'),
     )
 
 
 class Process(db.Model):
     id = db.Column(db.Integer(), unique=True)
+    path = db.Column(db.String(), nullable=False)
     runtime = db.Column(db.Integer())
     memory = db.Column(db.Integer())
     cpu = db.Column(db.Integer())
     files = db.Column(db.Integer())
     exits = db.Column(db.Integer())
     changes = db.Column(db.Integer())
-    last_update = db.Column(db.Integer())
-    executable_id = db.Column(db.Integer(), db.ForeignKey('executable.id'))
+    last_update = db.Column(db.DateTime())
+    update_interval = db.Column(db.Integer())
+    supervisor_id = db.Column(db.Integer(), db.ForeignKey('supervisor.id'))
 
     endpoints = db.relationship(
         'Endpoint', backref='process', lazy=True)
@@ -166,31 +169,19 @@ class Process(db.Model):
         'ConsolePage', backref='process', lazy=True)
 
     __table_args__ = (
-        db.PrimaryKeyConstraint('executable_id'),
-    )
-
-
-class Executable(db.Model):
-    id = db.Column(db.Integer(), unique=True)
-    path = db.Column(db.String(), nullable=False)
-    supervisor_id = db.Column(db.Integer(), db.ForeignKey('supervisor.id'))
-
-    process = db.relationship(
-        'Process', uselist=False, backref='executable', lazy=True)
-
-    __table_args__ = (
-        db.PrimaryKeyConstraint('path', 'supervisor_id'),
+        db.PrimaryKeyConstraint('supervisor_id', 'path'),
     )
 
 
 class Supervisor(db.Model):
     id = db.Column(db.Integer(), unique=True)
     hostname = db.Column(db.String(), nullable=False)
-    producer = db.Column(db.String(), nullable=False)
+    watch_dir = db.Column(db.String(), nullable=False)
+    started = db.Column(db.DateTime())
 
-    executables = db.relationship(
-        'Executable', backref='supervisor', lazy=True)
+    processes = db.relationship(
+        'Process', backref='supervisor', lazy=True)
 
     __table_args__ = (
-        db.PrimaryKeyConstraint('hostname', 'producer'),
+        db.PrimaryKeyConstraint('hostname'),
     )

--- a/snmpsim_control_plane/supervisor/manager.py
+++ b/snmpsim_control_plane/supervisor/manager.py
@@ -71,6 +71,8 @@ def _process_is_running(leash):
 def manage_executables(watch_dir):
     known_instances = {}
 
+    started = int(time.time())
+
     log.info('Watching directory %s' % watch_dir)
 
     while True:
@@ -258,6 +260,7 @@ def manage_executables(watch_dir):
                     log.info('Executable %s (PID %s) has '
                              'died' % (fl, leash.pid))
 
-        ReportingManager.process_metrics(*known_instances.values())
+        ReportingManager.process_metrics(
+            watch_dir, *known_instances.values())
 
         time.sleep(POLL_PERIOD)

--- a/snmpsim_control_plane/supervisor/reporting/collector.py
+++ b/snmpsim_control_plane/supervisor/reporting/collector.py
@@ -54,7 +54,7 @@ def collect_metrics(*instances):
             },
             'console': [
                 {
-                    'page': 0,  # page number
+                    'timestamp': {time},
                     'text': '{text}
                 }
             ]

--- a/snmpsim_control_plane/supervisor/reporting/formats/base.py
+++ b/snmpsim_control_plane/supervisor/reporting/formats/base.py
@@ -14,7 +14,8 @@ class BaseReporter(object):
     def __init__(self, *args, **kwargs):
         pass
 
-    def dump_metrics(self, metrics, begin=None, end=None):
+    def dump_metrics(self, metrics, watch_dir=None,
+                     started=None, begin=None, end=None):
         """Dump metrics in a reporter-specific way.
         """
 

--- a/snmpsim_control_plane/supervisor/reporting/formats/jsondoc.py
+++ b/snmpsim_control_plane/supervisor/reporting/formats/jsondoc.py
@@ -30,6 +30,8 @@ class JsonDocReporter(base.BaseReporter):
         'version': 1,
         'host': '{hostname}',
         'producer': <UUID>,
+        'watch_dir': '{dir}',
+        'uptime': 0,
         'first_update': '{timestamp}',
         'last_update': '{timestamp}',
         'executables': [
@@ -51,7 +53,6 @@ class JsonDocReporter(base.BaseReporter):
                 ],
                 'console': [
                     {
-                        'page': 0,
                         'timestamp': 0,
                         'text': '{text}'
                     }
@@ -110,7 +111,8 @@ class JsonDocReporter(base.BaseReporter):
 
         return obj
 
-    def dump_metrics(self, metrics, begin=None, end=None):
+    def dump_metrics(self, metrics, watch_dir=None,
+                     started=None, begin=None, end=None):
         """Dump metrics into a JSON file.
         """
         json_metrics = self._format_metrics(metrics)
@@ -119,6 +121,8 @@ class JsonDocReporter(base.BaseReporter):
         json_metrics['version'] = self.REPORTING_VERSION
         json_metrics['host'] = self.PRODUCER_HOST
         json_metrics['producer'] = self.PRODUCER_UUID
+        json_metrics['watch_dir'] = watch_dir
+        json_metrics['started'] = started
         json_metrics['first_update'] = int(begin)
         json_metrics['last_update'] = int(end)
 

--- a/snmpsim_control_plane/supervisor/reporting/manager.py
+++ b/snmpsim_control_plane/supervisor/reporting/manager.py
@@ -35,6 +35,8 @@ class ReportingManager(object):
         'jsondoc': jsondoc.JsonDocReporter,
     }
 
+    STARTED = int(time.time())
+
     _last_reportings = collections.defaultdict(dict)
 
     _reporter = null.NullReporter()
@@ -56,7 +58,7 @@ class ReportingManager(object):
                  'params %s' % (cls._reporter, ', '.join(args)))
 
     @classmethod
-    def process_metrics(cls, *instances):
+    def process_metrics(cls, watch_dir, *instances):
         now = int(time.time())
 
         if cls._next_dump > now:
@@ -86,4 +88,5 @@ class ReportingManager(object):
                 metrics[metric] = current_value.added_content(previous_value)
 
         cls._reporter.dump_metrics(
-            all_metrics, begin=int(last_dump), end=int(now))
+            all_metrics, watch_dir=watch_dir, started=cls.STARTED,
+            begin=int(last_dump), end=int(now))


### PR DESCRIPTION
Added SNMP simulator processes runtime metrics collection by the `supervisor` process. Gathered information is stored in the DB and served via newly introduced REST API endpoints.